### PR TITLE
Update mapbox to v1.5.0 (and add XSS protection)

### DIFF
--- a/public/hub_map.html
+++ b/public/hub_map.html
@@ -484,11 +484,6 @@ function initMap(hubs) {
     }
   });
 
-  map.on('moveend', function() {
-    var my = $('#hub-map .mapboxgl-popup')[0];
-    my.style.transform = my.style.transform.replace("-50%", "calc(-50% - 0.5px)");
-  });
-
   // This is where your interactions with the symbol layer used to be
   // Now you have interactions with DOM markers instead
   hubs.features.forEach(function(marker, i) {

--- a/public/hub_map.html
+++ b/public/hub_map.html
@@ -324,12 +324,34 @@ if (typeof(Array.prototype.unique) === "undefined") {
   }
 }
 
+function htmlEscape(s) {
+  return s.
+    replace(/&/g, "&amp;").
+    replace(/</g, "&lt;").
+    replace(/>/g, "&gt;").
+    replace(/"/g, "&quot;").
+    replace(/'/g, "&#x27;").
+    replace(/\//g, "&#x2F;");
+}
+
+function linkEscape(s) {
+  const escaped = s.trim().
+    replace(/</g, "&lt;").
+    replace(/>/g, "&gt;").
+    replace(/"/g, "&quot;").
+    replace(/'/g, "&#x27;");
+  if (escaped.match(/^\s*javascript/i))
+    return '';
+  else
+    return escaped;
+}
+
 function emailLink(email) {
-  return "<a href='mailto:" + email + "'>" + email + "</a>";
+  return `<a href="mailto:${htmlEscape(email)}">${htmlEscape(email)}</a>`;
 }
 
 function hubName(hub) {
-  return hub.name + "<br/><small>"+hub.city + ", " + hub.state+"</small>";
+  return `${htmlEscape(hub.name)}<br/><small>${htmlEscape(hub.city)}, ${htmlEscape(hub.state)}</small>`;
 }
 
 function socialLink(prefix, value, title) {
@@ -339,7 +361,7 @@ function socialLink(prefix, value, title) {
   } else {
     href = prefix + "/" + value.replace("@", "").trim();
   }
-  return '<a href="'+href+'" target="_blank" style="text-decoration:underline;">'+title+'</a>';
+  return `<a href="${linkEscape(href)}" target="_blank" style="text-decoration:underline;">${htmlEscape(title)}</a>`;
 }
 
 function socialP(prefix, value, title) {
@@ -357,22 +379,21 @@ function hubLinks(hub) {
   html += socialP("https://instagram.com", hub.instagram, "Instagram Page");
   if (hub.website) {
     var linkText = hub.custom_weblink_text || "Hub Website";
-    html += '<p><a href="'+ hub.website.trim() + '" target="_blank" style="text-decoration:underline;">' + linkText + '</a></p>';
+    html += `<p><a href="${linkEscape(hub.website)}" target="_blank" style="text-decoration:underline;">${htmlEscape(linkText)}</a></p>`;
   }
   if (hub.custom_coord_text) {
-    html += "<strong>Hub Contact:</strong><br>";
-    html += hub.custom_coord_text;
+    html += `<strong>Hub Contact:</strong><br>${htmlEscape(hub.custom_coord_text)}`;
   } else if (hub.email && !hub.leaders.length) {
-    html += "<strong>Hub Contact Email:</strong><br>" + emailLink(hub.email);
+    html += `<strong>Hub Contact Email:</strong><br>${emailLink(hub.email)}`;
   } else if (hub.leaders.length) {
     html += "<strong>Hub Contact"
     if (hub.leaders.length > 1 || hub.email) html += "s";
     html += ":</strong><br>";
     if (hub.email)
-      html += "<span>Hub Contact Email:</span> " + emailLink(hub.email) + "<br>";
+      html += `<span>Hub Contact Email:</span> ${emailLink(hub.email)}<br>`;
     for (var i=0; i < hub.leaders.length; i++) {
       var lead = hub.leaders[i];
-      html += "<span>"+lead.first_name + " " + lead.last_name + ":</span> ";
+      html += `<span>${htmlEscape(lead.first_name)} ${htmlEscape(lead.last_name)}:</span> `;
       html += emailLink(lead.email) + "<br>";
     }
   }

--- a/public/hub_map.html
+++ b/public/hub_map.html
@@ -1,5 +1,6 @@
 <!-- Include some styles from the main site (don't copy these) -->
 
+<meta charset='utf-8'/>
 <link rel='stylesheet' href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:700,600,700i&display=swap"/>
 <link rel='stylesheet' href="https://fonts.googleapis.com/css?family=Source+Serif+Pro:400,600,700,700i&display=swap"/>
 <style>

--- a/public/hub_map.html
+++ b/public/hub_map.html
@@ -32,7 +32,7 @@ h3 {
 
 <!-- Copy from here down -->
 
-<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.css' rel='stylesheet' />
+<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css' rel='stylesheet' />
 
 <style>
 
@@ -162,6 +162,7 @@ h3 {
   width: 56px;
   background-image: url(/s/map_icon.jpg);
   background-color: rgba(0, 0, 0, 0);
+  background-size: cover;
 }
 
 #hub-map .clearfix { display:block; }
@@ -306,7 +307,7 @@ h3 {
 </div>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.js'></script>
+<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js'></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
 
 <script>


### PR DESCRIPTION
Per an email from @alaurenz, mapbox is changing its billing structure (in a way that potentially helps us), but requires us to update to their new javascript API. This apparently didn't require any major changes, and also allowed us to remove a hack that fixed a blurry text issue which occurred under the old API version!

I also bundled this update together with some XSS protection code I had been working on (so that the data which populates the hub map can't inadvertently break parts of the page if it happens to contain closing tags / end-quotes).