### PR TITLE
Properly trigger microsites Gatsby publish after hub JSON upload

### DIFF
--- a/scripts/upload_hub_json.rb
+++ b/scripts/upload_hub_json.rb
@@ -26,8 +26,8 @@ if token = ENV['MICROSITE_GITHUB_ACCESS_TOKEN']
   HTTParty.post(
     "https://api.github.com/repos/sunrisemovement/smvmt-microsite/dispatches",
     body: {
-      event_type: 'deploy',
-    },
+      event_type: 'deploy'
+    }.to_json,
     headers: {
       "Authorization" => "token #{token}"
     }

--- a/scripts/upload_hub_json.rb
+++ b/scripts/upload_hub_json.rb
@@ -24,7 +24,10 @@ s3.put_object(
 if token = ENV['MICROSITE_GITHUB_ACCESS_TOKEN']
   # Deploy microsites
   HTTParty.post(
-    "https://api.github.com/repos/sunrisemovement/smvmt-microsite/pages/builds",
+    "https://api.github.com/repos/sunrisemovement/smvmt-microsite/dispatches",
+    body: {
+      event_type: 'deploy',
+    },
     headers: {
       "Authorization" => "token #{token}"
     }


### PR DESCRIPTION
See <https://goobar.io/manually-trigger-a-github-actions-workflow>; this should let us trigger Gatsby deploys via the API, for real this time!

Related PR: https://github.com/sunrisemovement/smvmt-microsite/pull/25